### PR TITLE
don't upload your own investigator file

### DIFF
--- a/cli/investigator/create.go
+++ b/cli/investigator/create.go
@@ -1,6 +1,7 @@
 package investigator
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,12 +23,7 @@ func createInvestigator(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	writePrivateKey(investigator, privateKeyPEM)
-	err = investigator.Upload()
-	if err != nil {
-		color.HiRed("Error uploading investigator: %s", err.Error())
-	} else {
-		color.HiGreen("Investigator setup complete, investigator is live")
-	}
+	writePublicKey(investigator)
 }
 
 func writePrivateKey(investigator engine.Investigator, privatePEM []byte) {
@@ -60,5 +56,25 @@ func writePrivateKey(investigator engine.Investigator, privatePEM []byte) {
 		color.HiRed("If you would like to replace your key, please remove this file.")
 		os.Exit(1)
 	}
-	ioutil.WriteFile(dexterKeyName, privatePEM, 0644)
+	err = ioutil.WriteFile(dexterKeyName, privatePEM, 0644)
+	if err != nil {
+		color.HiRed("fatal error writing investigator private key: " + err.Error())
+		os.Exit(1)
+	}
+}
+
+func writePublicKey(investigator engine.Investigator) {
+	data, err := json.MarshalIndent(investigator, "", "  ")
+	if err != nil {
+		color.HiRed("fatal error encoding investigator: " + err.Error())
+		os.Exit(1)
+	}
+
+	err = ioutil.WriteFile(investigator.Name+".json", data, 0644)
+	if err != nil {
+		color.HiRed("fatal error writing investigator file: " + err.Error())
+		os.Exit(1)
+	}
+	color.Green("New investigator file create: " + investigator.Name + ".json")
+	color.Yellow("This must be uploaded to Dexter by your Dexter administrator.")
 }

--- a/engine/investigator.go
+++ b/engine/investigator.go
@@ -57,23 +57,6 @@ func (investigator Investigator) String() ([]byte, error) {
 }
 
 //
-// Upload the investigator to S3
-//
-func (investigator Investigator) Upload() error {
-	data, err := json.MarshalIndent(investigator, "", "  ")
-	if err != nil {
-		return errors.New("fatal error encoding investigator definition: " + err.Error())
-	}
-
-	// Upload the investigator public key into the S3 directory
-	err = helpers.UploadS3File("investigators/"+investigator.Name+".json", bytes.NewReader(data))
-	if err != nil {
-		errors.New("fatal error uploading new investigator: " + err.Error())
-	}
-	return nil
-}
-
-//
 // Generate the keys for an investigator
 //
 func generateInvestigatorKeys(password string) ([]byte, *rsa.PublicKey, error) {

--- a/engine/investigator_test.go
+++ b/engine/investigator_test.go
@@ -2,7 +2,6 @@ package engine_test
 
 import (
 	"github.com/coinbase/dexter/engine"
-	"github.com/coinbase/dexter/engine/helpers"
 	"github.com/stretchr/testify/assert"
 
 	"testing"
@@ -25,20 +24,4 @@ func TestInvestigatorCanMakeString(t *testing.T) {
 	assert.Nil(err)
 	_, err = investigator.String()
 	assert.Nil(err)
-}
-
-func TestInvestigatorCanUploadAndRetrieve(t *testing.T) {
-	helpers.LocalDemoPath = "/tmp/dexter/"
-	helpers.BuildDemoPath()
-	assert := assert.New(t)
-
-	investigator, _, err := engine.NewInvestigator("bob", "password")
-	assert.Nil(err)
-
-	err = investigator.Upload()
-	assert.Nil(err)
-	investigators := engine.LoadInvestigators()
-	if assert.Equal(1, len(investigators)) {
-		assert.Equal("bob", investigators[0].Name)
-	}
 }


### PR DESCRIPTION
Being able to write your own public key to S3 means that you could bypass consensus by adding multiple public keys once you are granted access.  There are several protections that could be put in place here (including having multiple other investigators sign your key, adding alerting for new keys and a delay period before keys are valid, etc) but the simplest is to create a role that is separate from investigators and able to upload keys.

This change will create the investigator file locally, so that it can be passed to an administrator who can upload it to S3.